### PR TITLE
requirements.txtを追加

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+django
+django-allauth
+pillow


### PR DESCRIPTION
`pip install -r requirements.txt` で必要なパッケージをインストールできるようになる。レガシーな方法。